### PR TITLE
Loading screen

### DIFF
--- a/core/src/com/dokkaebistudio/tacticaljourney/Assets.java
+++ b/core/src/com/dokkaebistudio/tacticaljourney/Assets.java
@@ -17,19 +17,19 @@
 package com.dokkaebistudio.tacticaljourney;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Animation;
 import com.badlogic.gdx.graphics.g2d.Animation.PlayMode;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 
 public class Assets {
-	public static Texture background;
-	public static TextureRegion backgroundRegion;
-	public static Texture menuBackground;
-	public static TextureRegion menuBackgroundRegion;
+	public static final String background = "data/background-test.png";
+	public static final String menuBackground = "data/background-test-menu.png";
 
 	public static Texture items;
 	public static TextureRegion mainMenu;
@@ -60,17 +60,79 @@ public class Assets {
 	public static Sound coinSound;
 	public static Sound clickSound;
 
+	private static Assets instance;
+	private AssetManager manager;
+
+	public static Assets getInstance() {
+		if (instance == null) {
+			instance = new Assets();
+		}
+		return instance;
+	}
+
+	public Assets() {
+		manager = new AssetManager();
+		registerAssets();
+	}
+
+	/**
+	 * This doesn't load the textures yet, it simply adds files to the list of assets to load.
+	 * Loading will be done by calling load on the AssetManager a bunch of times until it's done.
+	 */
+	private void registerAssets() {
+		// register textures
+		registerTexture(background);
+		registerTexture(menuBackground);
+
+		// TODO register texture atlases
+
+		// TODO register fonts
+
+		// TODO register animations
+
+		// TODO register sounds
+
+	}
+
+	/**
+	 * Loads some assets, call this in the render loop of the loading screen.
+	 * @return True if all is loaded.
+	 */
+	public boolean loadAssets() {
+		return manager.update();
+	}
+
+	/**
+	 * Returns asset loading progress in percentage (0-100).
+	 */
+	public float getLoadingProgress() {
+		return manager.getProgress() * 100;
+	}
+
+	private void registerTextureAtlas(String atlasFile) {
+		this.manager.load(atlasFile, TextureAtlas.class);
+	}
+	public static TextureAtlas getTextureAtlas(String file){
+		return getInstance().manager.get(file, TextureAtlas.class);
+	}
+
+	private void registerTexture(String file) {
+		this.manager.load(file, Texture.class);
+	}
+
+	public static Texture getTexture(String file){
+		return getInstance().manager.get(file, Texture.class);
+	}
+
+
+
+	// OLD DUMB SYNCHRONOUS WAY
+
 	public static Texture loadTexture (String file) {
 		return new Texture(Gdx.files.internal(file));
 	}
 
 	public static void load () {
-		background = loadTexture("data/background-test.png");
-		backgroundRegion = new TextureRegion(background, 0, 0, 1920, 1080);
-		
-		menuBackground = loadTexture("data/background-test-menu.png");
-		menuBackgroundRegion = new TextureRegion(menuBackground, 0, 0, 1920, 1080);
-
 		items = loadTexture("data/items.png");
 		mainMenu = new TextureRegion(items, 0, 224, 300, 110);
 		pauseMenu = new TextureRegion(items, 224, 128, 192, 96);

--- a/core/src/com/dokkaebistudio/tacticaljourney/Assets.java
+++ b/core/src/com/dokkaebistudio/tacticaljourney/Assets.java
@@ -31,7 +31,16 @@ public class Assets {
 	public static final String background = "data/background-test.png";
 	public static final String menuBackground = "data/background-test-menu.png";
 
-	public static Texture items;
+	public static String items = "data/items.png";
+
+	public static String music = "data/music.mp3";
+	public static String jumpSound = "data/jump.wav";
+	public static String highJumpSound = "data/highjump.wav";
+	public static String hitSound = "data/hit.wav";
+	public static String coinSound = "data/coin.wav";
+	public static String clickSound = "data/click.wav";
+
+
 	public static TextureRegion mainMenu;
 	public static TextureRegion pauseMenu;
 	public static TextureRegion ready;
@@ -52,13 +61,6 @@ public class Assets {
 	public static Animation platform;
 	public static Animation breakingPlatform;
 	public static BitmapFont font;
-
-	public static Music music;
-	public static Sound jumpSound;
-	public static Sound highJumpSound;
-	public static Sound hitSound;
-	public static Sound coinSound;
-	public static Sound clickSound;
 
 	private static Assets instance;
 	private AssetManager manager;
@@ -83,15 +85,17 @@ public class Assets {
 		// register textures
 		registerTexture(background);
 		registerTexture(menuBackground);
+		registerTexture(items);
 
-		// TODO register texture atlases
+		// TODO register texture atlases (they need to be generated first)
 
-		// TODO register fonts
-
-		// TODO register animations
-
-		// TODO register sounds
-
+		// register music and sounds
+		registerMusic(music);
+		registerSound(jumpSound);
+		registerSound(highJumpSound);
+		registerSound(hitSound);
+		registerSound(coinSound);
+		registerSound(clickSound);
 	}
 
 	/**
@@ -113,15 +117,35 @@ public class Assets {
 		this.manager.load(atlasFile, TextureAtlas.class);
 	}
 	public static TextureAtlas getTextureAtlas(String file){
-		return getInstance().manager.get(file, TextureAtlas.class);
+		return getInstance().manager.get(file);
 	}
 
 	private void registerTexture(String file) {
 		this.manager.load(file, Texture.class);
 	}
-
 	public static Texture getTexture(String file){
-		return getInstance().manager.get(file, Texture.class);
+		return getInstance().manager.get(file);
+	}
+
+	private void registerMusic(String file) {
+		this.manager.load(file, Music.class);
+	}
+	public static Music getMusic(String file) {
+		return getInstance().manager.get(file);
+	}
+
+	private void registerSound(String file) {
+		this.manager.load(file, Sound.class);
+	}
+	public static Sound getSound(String file){
+		return getInstance().manager.get(file);
+	}
+
+	/**
+	 * Should be called as soon as possible to display loading info.
+	 */
+	public void loadFont() {
+		font = new BitmapFont(Gdx.files.internal("data/font.fnt"), Gdx.files.internal("data/font.png"), false);
 	}
 
 
@@ -132,52 +156,52 @@ public class Assets {
 		return new Texture(Gdx.files.internal(file));
 	}
 
-	public static void load () {
-		items = loadTexture("data/items.png");
-		mainMenu = new TextureRegion(items, 0, 224, 300, 110);
-		pauseMenu = new TextureRegion(items, 224, 128, 192, 96);
-		ready = new TextureRegion(items, 320, 224, 192, 32);
-		gameOver = new TextureRegion(items, 352, 256, 160, 96);
-		highScoresRegion = new TextureRegion(Assets.items, 0, 257, 300, 110 / 3);
-		logo = new TextureRegion(items, 0, 352, 274, 142);
-		soundOff = new TextureRegion(items, 0, 0, 64, 64);
-		soundOn = new TextureRegion(items, 64, 0, 64, 64);
-		arrow = new TextureRegion(items, 0, 64, 64, 64);
-		pause = new TextureRegion(items, 64, 64, 64, 64);
+	public void finalizeLoading() {
+		// create regions
+		Texture itemsTex = getTexture(items);
+		mainMenu = new TextureRegion(itemsTex, 0, 224, 300, 110);
+		pauseMenu = new TextureRegion(itemsTex, 224, 128, 192, 96);
+		ready = new TextureRegion(itemsTex, 320, 224, 192, 32);
+		gameOver = new TextureRegion(itemsTex, 352, 256, 160, 96);
+		highScoresRegion = new TextureRegion(itemsTex, 0, 257, 300, 110 / 3);
+		logo = new TextureRegion(itemsTex, 0, 352, 274, 142);
+		soundOff = new TextureRegion(itemsTex, 0, 0, 64, 64);
+		soundOn = new TextureRegion(itemsTex, 64, 0, 64, 64);
+		arrow = new TextureRegion(itemsTex, 0, 64, 64, 64);
+		pause = new TextureRegion(itemsTex, 64, 64, 64, 64);
+		spring = new TextureRegion(itemsTex, 128, 0, 32, 32);
+		castle = new TextureRegion(itemsTex, 128, 64, 64, 64);
 
-		spring = new TextureRegion(items, 128, 0, 32, 32);
-		castle = new TextureRegion(items, 128, 64, 64, 64);
-		coinAnim = new Animation(0.2f, new TextureRegion(items, 128, 32, 32, 32), new TextureRegion(items, 160, 32, 32, 32),
-			new TextureRegion(items, 192, 32, 32, 32), new TextureRegion(items, 160, 32, 32, 32));
-		bobJump = new Animation(0.2f, new TextureRegion(items, 0, 128, 32, 32), new TextureRegion(items, 32, 128, 32, 32));
-		bobFall = new Animation(0.2f, new TextureRegion(items, 64, 128, 32, 32), new TextureRegion(items, 96, 128, 32, 32));
-		bobHit = new Animation(0.2f, new TextureRegion(items, 128, 128, 32, 32));
-		squirrelFly = new Animation(0.2f, new TextureRegion(items, 0, 160, 32, 32), new TextureRegion(items, 32, 160, 32, 32));
-		platform = new Animation(0.2f, new TextureRegion(items, 64, 160, 64, 16));
-		breakingPlatform = new Animation(0.2f, new TextureRegion(items, 64, 160, 64, 16), new TextureRegion(items, 64, 176, 64, 16),
-			new TextureRegion(items, 64, 192, 64, 16), new TextureRegion(items, 64, 208, 64, 16));
+		// animations
+		coinAnim = new Animation(0.2f, new TextureRegion(itemsTex, 128, 32, 32, 32), new TextureRegion(itemsTex, 160, 32, 32, 32),
+			new TextureRegion(itemsTex, 192, 32, 32, 32), new TextureRegion(itemsTex, 160, 32, 32, 32));
+		bobJump = new Animation(0.2f, new TextureRegion(itemsTex, 0, 128, 32, 32), new TextureRegion(itemsTex, 32, 128, 32, 32));
+		bobFall = new Animation(0.2f, new TextureRegion(itemsTex, 64, 128, 32, 32), new TextureRegion(itemsTex, 96, 128, 32, 32));
+		bobHit = new Animation(0.2f, new TextureRegion(itemsTex, 128, 128, 32, 32));
+		squirrelFly = new Animation(0.2f, new TextureRegion(itemsTex, 0, 160, 32, 32), new TextureRegion(itemsTex, 32, 160, 32, 32));
+		platform = new Animation(0.2f, new TextureRegion(itemsTex, 64, 160, 64, 16));
+		breakingPlatform = new Animation(0.2f, new TextureRegion(itemsTex, 64, 160, 64, 16), new TextureRegion(itemsTex, 64, 176, 64, 16),
+			new TextureRegion(itemsTex, 64, 192, 64, 16), new TextureRegion(itemsTex, 64, 208, 64, 16));
 
-		font = new BitmapFont(Gdx.files.internal("data/font.fnt"), Gdx.files.internal("data/font.png"), false);
-
-		music = Gdx.audio.newMusic(Gdx.files.internal("data/music.mp3"));
-		music.setLooping(true);
-		music.setVolume(0.5f);
-		if (Settings.soundEnabled) music.play();
-		jumpSound = Gdx.audio.newSound(Gdx.files.internal("data/jump.wav"));
-		highJumpSound = Gdx.audio.newSound(Gdx.files.internal("data/highjump.wav"));
-		hitSound = Gdx.audio.newSound(Gdx.files.internal("data/hit.wav"));
-		coinSound = Gdx.audio.newSound(Gdx.files.internal("data/coin.wav"));
-		clickSound = Gdx.audio.newSound(Gdx.files.internal("data/click.wav"));
-		
+		// animations playing on loop
 		coinAnim.setPlayMode(PlayMode.LOOP);
 		bobJump.setPlayMode(PlayMode.LOOP);
 		bobFall.setPlayMode(PlayMode.LOOP);
 		bobHit.setPlayMode(PlayMode.LOOP);
 		squirrelFly.setPlayMode(PlayMode.LOOP);
 		platform.setPlayMode(PlayMode.LOOP);
+
+		// set music settings
+		Music musicAsset = getMusic(music);
+		musicAsset.setLooping(true);
+		musicAsset.setVolume(0.5f);
+		if (Settings.soundEnabled) musicAsset.play();
+
 	}
 
-	public static void playSound (Sound sound) {
-		if (Settings.soundEnabled) sound.play(1);
+	public static void playSound (String sound) {
+		if (Settings.soundEnabled) {
+			getSound(sound).play(1);
+		}
 	}
 }

--- a/core/src/com/dokkaebistudio/tacticaljourney/LoadingScreen.java
+++ b/core/src/com/dokkaebistudio/tacticaljourney/LoadingScreen.java
@@ -22,8 +22,6 @@ import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
-import com.badlogic.gdx.math.Rectangle;
-import com.badlogic.gdx.math.Vector3;
 
 public class LoadingScreen extends ScreenAdapter {
 	TacticalJourney game;
@@ -39,10 +37,17 @@ public class LoadingScreen extends ScreenAdapter {
 	}
 
 	public int load(){
+	    // call asset manager loading each tick
 		boolean loaded = Assets.getInstance().loadAssets();
-		if (loaded) { // loading is finished ! Change screen
+
+		if (loaded) { // loading is finished !
+		    // create regions and shit
+            Assets.getInstance().finalizeLoading();
+            // change screen
 			this.game.setScreen(new MainMenuScreen(this.game));
 		}
+
+		// report progress
 		return (int)Assets.getInstance().getLoadingProgress();
 	}
 
@@ -58,7 +63,7 @@ public class LoadingScreen extends ScreenAdapter {
 		// draw loading text in the center
 		String text = "LOADING - " + progress + "%";
 		GlyphLayout loadingLayout = new GlyphLayout();
-		// update layout. It is used to compute the real text height and width to aid positionning
+		// update layout. It is used to compute the real text height and width to aid positioning
 		loadingLayout.setText(Assets.font, text);
 		Assets.font.draw(game.batcher, loadingLayout, 1920/2 - loadingLayout.width, 1080/2 - loadingLayout.height);
 		game.batcher.end();	

--- a/core/src/com/dokkaebistudio/tacticaljourney/MainMenuScreen.java
+++ b/core/src/com/dokkaebistudio/tacticaljourney/MainMenuScreen.java
@@ -19,11 +19,14 @@ package com.dokkaebistudio.tacticaljourney;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector3;
+
+import java.applet.Applet;
 
 public class MainMenuScreen extends ScreenAdapter {
 	TacticalJourney game;
@@ -35,6 +38,7 @@ public class MainMenuScreen extends ScreenAdapter {
 	Vector3 touchPoint;
 
 	Texture menuBackground;
+	private Music music;
 
 	public MainMenuScreen (TacticalJourney game) {
 		this.game = game;
@@ -48,6 +52,7 @@ public class MainMenuScreen extends ScreenAdapter {
 
 		// should be already loaded
 		menuBackground = Assets.getTexture(Assets.menuBackground);
+		music = Assets.getMusic(Assets.music);
 	}
 
 	public void update () {
@@ -63,9 +68,9 @@ public class MainMenuScreen extends ScreenAdapter {
 				Assets.playSound(Assets.clickSound);
 				Settings.soundEnabled = !Settings.soundEnabled;
 				if (Settings.soundEnabled)
-					Assets.music.play();
+					this.music.play();
 				else
-					Assets.music.pause();
+					this.music.pause();
 			}
 		}
 	}

--- a/core/src/com/dokkaebistudio/tacticaljourney/TacticalJourney.java
+++ b/core/src/com/dokkaebistudio/tacticaljourney/TacticalJourney.java
@@ -30,7 +30,7 @@ public class TacticalJourney extends Game {
 		batcher = new SpriteBatch();
 		Settings.load();
 		Assets.load();
-		setScreen(new MainMenuScreen(this));
+		setScreen(new LoadingScreen(this));
 	}
 	
 	@Override

--- a/core/src/com/dokkaebistudio/tacticaljourney/TacticalJourney.java
+++ b/core/src/com/dokkaebistudio/tacticaljourney/TacticalJourney.java
@@ -29,7 +29,7 @@ public class TacticalJourney extends Game {
 	public void create () {
 		batcher = new SpriteBatch();
 		Settings.load();
-		Assets.load();
+		Assets.getInstance().loadFont();
 		setScreen(new LoadingScreen(this));
 	}
 	

--- a/core/src/com/dokkaebistudio/tacticaljourney/World.java
+++ b/core/src/com/dokkaebistudio/tacticaljourney/World.java
@@ -20,6 +20,7 @@ import java.util.Random;
 
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.ashley.core.PooledEngine;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.dokkaebistudio.tacticaljourney.components.TextureComponent;
 import com.dokkaebistudio.tacticaljourney.components.TransformComponent;
 
@@ -56,7 +57,7 @@ public class World {
 		TransformComponent position = engine.createComponent(TransformComponent.class);
 		TextureComponent texture = engine.createComponent(TextureComponent.class);
 		
-		texture.region = Assets.backgroundRegion;
+		texture.region = new TextureRegion(Assets.getTexture(Assets.background));
 		
 		backgroundEntity.add(position);
 		backgroundEntity.add(texture);


### PR DESCRIPTION
Implemented loading screen and async loading via assetManager.
Process of loading is:
- App starts, loads the font so the loading screen can display text
- Loading Screen is displayed
  - In `Assets`, an `AssetManager` is created and all assets are registered in it (not yet loaded).
  - Each frame load() is called on `AssetManager` so it loads the assets
  - Loading progress is displayed and updated each frame
- When the `AssetManager` has loaded everything
  - TexturesRegions are created from Textures
  - Music settings
- Then change screen to MainMenuScreen.



Next would be to use TextureAtlas instead of using a Texture and splitting it in TextureRegions. The advantage of the TextureAtlas is that all the subTextures positions are stored in the atlas and not hard-coded. 
Instead of 
```java
TextureRegion mainMenu = new TextureRegion(itemsTex, 0, 224, 300, 110);
```
we would have
```java
AtlasRegion mainMenu = itemAtlas.findRegion("mainMenu");
```